### PR TITLE
Fix for 400

### DIFF
--- a/src/components/ContainerHomeWebPreview.react.js
+++ b/src/components/ContainerHomeWebPreview.react.js
@@ -7,7 +7,7 @@ var ContainerHomeWebPreview = React.createClass({
     metrics.track('Opened In Browser', {
       from: 'preview'
     });
-    shell.openExternal('http://' + this.props.ports[this.props.defaultPort].url);
+    shell.openExternal('https://' + this.props.ports[this.props.defaultPort].url);
   },
 
   handleClickPortSettings: function () {


### PR DESCRIPTION
Http should be https. Below is the error when stubbornly code http. Worst case user specific weaker/no encryption

400 Bad Request

The plain HTTP request was sent to HTTPS port
nginx/1.10.2